### PR TITLE
xtensa-dynconfig: add xtensa_config_v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ SOURCE_FILES = xtensa-config.c \
 	       $(CONF_DIR)/%/gdb/gdb/xtensa-xtregs.c
 
 INCLUDE += -Iinclude \
-           -I$(CONF_DIR)/$*/binutils/include
+           -I$(CONF_DIR)/$*/binutils/include \
+           -I$(CONF_DIR)/$*/newlib/newlib/libc/sys/xtensa/include/xtensa/config
 
 CFLAGS += $(INCLUDE) -fPIC -O2
 

--- a/include/xtensa-dynconfig.h
+++ b/include/xtensa-dynconfig.h
@@ -112,6 +112,14 @@ struct xtensa_config_v3
   int xchal_have_xea3;
 };
 
+struct xtensa_config_v4
+{
+  int xchal_unaligned_load_exception;
+  int xchal_mayhave_erratum_xea1kwin;
+  int xchal_have_flix3;
+  int xchal_have_pdx4;
+};
+
 typedef struct xtensa_isa_internal_struct xtensa_isa_internal;
 
 extern const void *xtensa_load_config (const char *name,
@@ -120,6 +128,7 @@ extern const void *xtensa_load_config (const char *name,
 extern const struct xtensa_config_v1 *xtensa_get_config_v1 (void);
 extern const struct xtensa_config_v2 *xtensa_get_config_v2 (void);
 extern const struct xtensa_config_v3 *xtensa_get_config_v3 (void);
+extern const struct xtensa_config_v4 *xtensa_get_config_v4 (void);
 
 #ifdef XTENSA_CONFIG_DEFINITION
 
@@ -207,6 +216,22 @@ extern const struct xtensa_config_v3 *xtensa_get_config_v3 (void);
 #define XCHAL_HAVE_XEA3 0
 #endif
 
+#ifndef XCHAL_UNALIGNED_LOAD_EXCEPTION
+#define XCHAL_UNALIGNED_LOAD_EXCEPTION 0
+#endif
+
+#ifndef XCHAL_MAYHAVE_ERRATUM_XEA1KWIN
+#define XCHAL_MAYHAVE_ERRATUM_XEA1KWIN 0
+#endif
+
+#ifndef XCHAL_HAVE_FLIX3
+#define XCHAL_HAVE_FLIX3 0
+#endif
+
+#ifndef XCHAL_HAVE_PDX4
+#define XCHAL_HAVE_PDX4 0
+#endif
+
 #define XTENSA_CONFIG_ENTRY(a) a
 
 #define XTENSA_CONFIG_V1_ENTRY_LIST \
@@ -276,6 +301,12 @@ extern const struct xtensa_config_v3 *xtensa_get_config_v3 (void);
     XTENSA_CONFIG_ENTRY(XCHAL_HAVE_EXCLUSIVE), \
     XTENSA_CONFIG_ENTRY(XCHAL_HAVE_XEA3)
 
+#define XTENSA_CONFIG_V4_ENTRY_LIST \
+    XTENSA_CONFIG_ENTRY(XCHAL_UNALIGNED_LOAD_EXCEPTION), \
+    XTENSA_CONFIG_ENTRY(XCHAL_MAYHAVE_ERRATUM_XEA1KWIN), \
+    XTENSA_CONFIG_ENTRY(XCHAL_HAVE_FLIX3), \
+    XTENSA_CONFIG_ENTRY(XCHAL_HAVE_PDX4)
+
 #define XTENSA_CONFIG_INSTANCE_LIST \
 const struct xtensa_config_v1 xtensa_config_v1 = { \
     XTENSA_CONFIG_V1_ENTRY_LIST, \
@@ -285,12 +316,16 @@ const struct xtensa_config_v2 xtensa_config_v2 = { \
 }; \
 const struct xtensa_config_v3 xtensa_config_v3 = { \
     XTENSA_CONFIG_V3_ENTRY_LIST, \
+}; \
+const struct xtensa_config_v4 xtensa_config_v4 = { \
+    XTENSA_CONFIG_V4_ENTRY_LIST, \
 }
 
 #define XTENSA_CONFIG_ENTRY_LIST \
     XTENSA_CONFIG_V1_ENTRY_LIST, \
     XTENSA_CONFIG_V2_ENTRY_LIST, \
-    XTENSA_CONFIG_V3_ENTRY_LIST
+    XTENSA_CONFIG_V3_ENTRY_LIST, \
+    XTENSA_CONFIG_V4_ENTRY_LIST
 
 #else /* XTENSA_CONFIG_DEFINITION */
 
@@ -481,6 +516,19 @@ const struct xtensa_config_v3 xtensa_config_v3 = { \
 
 #undef XCHAL_HAVE_XEA3
 #define XCHAL_HAVE_XEA3			(xtensa_get_config_v3 ()->xchal_have_xea3)
+
+
+#undef XCHAL_UNALIGNED_LOAD_EXCEPTION
+#define XCHAL_UNALIGNED_LOAD_EXCEPTION		(xtensa_get_config_v4 ()->xchal_unaligned_load_exception)
+
+#undef XCHAL_MAYHAVE_ERRATUM_XEA1KWIN
+#define XCHAL_MAYHAVE_ERRATUM_XEA1KWIN		(xtensa_get_config_v4 ()->xchal_mayhave_erratum_xea1kwin)
+
+#undef XCHAL_HAVE_FLIX3
+#define XCHAL_HAVE_FLIX3		(xtensa_get_config_v4 ()->xchal_have_flix3)
+
+#undef XCHAL_HAVE_PDX4
+#define XCHAL_HAVE_PDX4			(xtensa_get_config_v4 ()->xchal_have_pdx4)
 
 #endif /* XTENSA_CONFIG_DEFINITION */
 

--- a/xtensa-config.c
+++ b/xtensa-config.c
@@ -24,6 +24,17 @@
 #include <stdlib.h>
 #define XTENSA_CONFIG_DEFINITION
 #include <xtensa-config.h>
+/* Define macros just to make compiler happy.
+ * These values will not use in dynconfig.
+ */
+#define XTHAL_TIMER_UNCONFIGURED -1
+#define XTHAL_INTTYPE_EXTERN_LEVEL
+#define XTHAL_INTTYPE_TIMER
+#define XTHAL_INTTYPE_SOFTWARE
+#define XTHAL_INTTYPE_EXTERN_EDGE
+#define XTHAL_INTTYPE_PROFILING
+#define XTHAL_INTTYPE_NMI
+#include <core-isa.h>
 #include <xtensa-dynconfig.h>
 
 #undef XTENSA_CONFIG_ENTRY


### PR DESCRIPTION
Add configs from newlib overlay.

Following questions:
- What to do with `XCHAL_INT0_TYPE`..`XCHAL_INT31_TYPE` definitions which depend on `XTHAL_...` macros? 
- `XTHAL_TIMER_UNCONFIGURED` needs to be defined when building dynconfig. I defined it with `-1` in this PR. Is it ok? 
- All `XCHAL_HW_REL_LX...` need to be supported? Only XCHAL_HW_REL_LX7/XCHAL_HW_REL_LX7_0/XCHAL_HW_REL_LX7_0_12 are supported in this patch